### PR TITLE
Display at least one column of tiles

### DIFF
--- a/dist/tileview.js
+++ b/dist/tileview.js
@@ -320,7 +320,7 @@
                         var newItemsPerRow = (scope.options.alignHorizontal) ? 1 : Math.floor(width / itemWidth);
                         var newCachedRowCount = Math.ceil(size / scope.options.tileSize[sizeDimension]) + scope.options.overflow * 2;
                         var changes = newItemsPerRow !== itemsPerRow || newCachedRowCount !== cachedRowCount;
-                        itemsPerRow = newItemsPerRow;
+                        itemsPerRow = Math.max(newItemsPerRow, 1);
                         cachedRowCount = newCachedRowCount;
                         rowCount = Math.ceil(scope.items.length / itemsPerRow);
                         return changes;

--- a/src/tileview.ts
+++ b/src/tileview.ts
@@ -366,7 +366,7 @@ declare const angular: any;
           const newCachedRowCount = Math.ceil(size / scope.options.tileSize[sizeDimension]) + scope.options.overflow * 2;
 
           const changes = newItemsPerRow !== itemsPerRow || newCachedRowCount !== cachedRowCount;
-          itemsPerRow = newItemsPerRow;
+          itemsPerRow = Math.max(newItemsPerRow, 1);
           cachedRowCount = newCachedRowCount;
           rowCount = Math.ceil(scope.items.length / itemsPerRow);
           return changes;


### PR DESCRIPTION
When the viewport gets too small (narrow) the tile view should still display at least one column of tiles.